### PR TITLE
Add reinpaint API and mask editor

### DIFF
--- a/camelia-ui/components/MaskEditor.vue
+++ b/camelia-ui/components/MaskEditor.vue
@@ -1,0 +1,75 @@
+<template>
+  <div class="fixed inset-0 bg-base bg-opacity-80 flex items-center justify-center z-50">
+    <div class="bg-surface p-4 rounded-lg border border-overlay">
+      <div class="relative">
+        <img :src="image" alt="image" ref="imgRef" class="max-w-full max-h-[80vh]" @load="initCanvas" />
+        <canvas
+          ref="canvas"
+          class="absolute top-0 left-0"
+          @mousedown="start"
+          @mousemove="move"
+          @mouseup="end"
+          @mouseleave="end" />
+      </div>
+      <div class="mt-4 flex justify-end space-x-2">
+        <button class="px-3 py-1 rounded bg-muted" @click="$emit('close')">Cancel</button>
+        <button class="px-3 py-1 rounded bg-iris" @click="emitSave">Save Mask</button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue';
+
+const props = defineProps<{ image: string }>();
+const emit = defineEmits<{ (e: 'save', blob: Blob): void; (e: 'close'): void }>();
+
+const canvas = ref<HTMLCanvasElement | null>(null);
+const imgRef = ref<HTMLImageElement | null>(null);
+let drawing = false;
+let ctx: CanvasRenderingContext2D | null = null;
+
+function initCanvas() {
+  if (!canvas.value || !imgRef.value) return;
+  canvas.value.width = imgRef.value.naturalWidth;
+  canvas.value.height = imgRef.value.naturalHeight;
+  ctx = canvas.value.getContext('2d');
+  if (ctx) {
+    ctx.strokeStyle = '#ffffff';
+    ctx.lineWidth = 20;
+    ctx.lineCap = 'round';
+  }
+}
+
+function start(e: MouseEvent) {
+  if (!ctx) return;
+  drawing = true;
+  ctx.beginPath();
+  ctx.moveTo(e.offsetX, e.offsetY);
+}
+
+function move(e: MouseEvent) {
+  if (!drawing || !ctx) return;
+  ctx.lineTo(e.offsetX, e.offsetY);
+  ctx.stroke();
+}
+
+function end() {
+  drawing = false;
+}
+
+function emitSave() {
+  if (!canvas.value) return;
+  canvas.value.toBlob((blob) => {
+    if (blob) emit('save', blob);
+  });
+}
+</script>
+
+<style scoped>
+canvas {
+  pointer-events: auto;
+  cursor: crosshair;
+}
+</style>

--- a/camelia-ui/pages/index.vue
+++ b/camelia-ui/pages/index.vue
@@ -16,7 +16,7 @@
             :isVisible="isProcessing || showLogs"
             @closeConsole="hideConsole" />
 
-        <ResultsDisplay :results="results" />
+        <ResultsDisplay v-model:results="results" />
 
         <ErrorMessage :message="errorMessage" />
     </main>

--- a/camelia-ui/services/api.ts
+++ b/camelia-ui/services/api.ts
@@ -2,6 +2,7 @@ const API_BASE_URL: string = 'http://localhost:5000/api';
 
 export interface ResultItem {
     filename: string;
+    sessionId: string;
     original: string;
     processed: string;
 }
@@ -107,6 +108,7 @@ export function transformResults(
     return results.map((result) => {
         return {
             filename: result.filename,
+            sessionId,
             original: `${API_BASE_URL}/original/${result.filename}`,
             processed: `${API_BASE_URL}/results/${sessionId}/${result.filename}`
         };
@@ -133,4 +135,37 @@ export async function cancelProcessingJob(sessionId: string): Promise<boolean> {
         console.error('Error cancelling job:', error);
         return false;
     }
+}
+
+/**
+ * Send an edited mask to the server and get the new result
+ */
+export async function reinpaintImage(
+    sessionId: string,
+    filename: string,
+    mask: Blob
+): Promise<ResultItem> {
+    const formData = new FormData();
+    formData.append('mask', mask, 'mask.png');
+
+    const response = await fetch(
+        `${API_BASE_URL}/reinpaint/${sessionId}/${filename}`,
+        {
+            method: 'POST',
+            body: formData
+        }
+    );
+
+    const data = await response.json();
+
+    if (!response.ok || !data.success) {
+        throw new Error(data.error || 'Failed to reinpaint image');
+    }
+
+    return {
+        filename: data.filename,
+        sessionId,
+        original: `${API_BASE_URL}/original/${filename}`,
+        processed: `${API_BASE_URL}/results/${sessionId}/${data.filename}`
+    };
 }


### PR DESCRIPTION
## Summary
- allow re-inpainting by uploading a mask with `/api/reinpaint/<session_id>/<filename>`
- provide a simple canvas-based `MaskEditor` component
- add "Edit Mask" button in `ResultsDisplay` and wire up editor
- keep result list reactive and pass via `v-model`

## Testing
- `python -m py_compile api.py main.py`
- `npx -y tsc -p camelia-ui/tsconfig.json --noEmit` *(fails: Cannot read file '/workspace/camelia/camelia-ui/.nuxt/tsconfig.json'. ...)*

------
https://chatgpt.com/codex/tasks/task_e_6840f7e1a4f8832dac569458e94d2f4f