### PR TITLE
Add API env vars and runtime config

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,11 @@ Download the models here: [models](https://drive.google.com/drive/folders/1AAyv6
 
 Put the segmentation models in smp-segmentation/pretrained and inpainting model (the whole folder) in lama-inpainting/pretrained.
 
+### Environment Variables
+
+- `API_PORT` - Port for the Flask API server. Defaults to `5000`.
+- `API_BASE_URL` - Base URL used by the web UI to contact the API. Defaults to `http://localhost:5000/api`.
+
 ## Usage
 
 ### CLI Mode

--- a/api.py
+++ b/api.py
@@ -485,4 +485,4 @@ if __name__ == '__main__':
     # Ensure output directories exist
     ensure_directory(CAMELIA_TEMP)
     ensure_directory(CAMELIA_OUTPUT)
-    app.run(host='0.0.0.0', port=5000, debug=True)
+    app.run(host='0.0.0.0', port=int(os.environ.get("API_PORT", "5000")), debug=True)

--- a/camelia-ui/nuxt.config.ts
+++ b/camelia-ui/nuxt.config.ts
@@ -2,6 +2,11 @@
 import tailwindcss from '@tailwindcss/vite';
 
 export default defineNuxtConfig({
+    runtimeConfig: {
+        public: {
+            apiBaseUrl: process.env.API_BASE_URL || 'http://localhost:5000/api'
+        }
+    },
     compatibilityDate: '2024-11-01',
     devtools: { enabled: true },
     css: ['~/assets/css/main.css'],

--- a/camelia-ui/services/api.ts
+++ b/camelia-ui/services/api.ts
@@ -1,4 +1,4 @@
-const API_BASE_URL: string = 'http://localhost:5000/api';
+const API_BASE_URL: string = useRuntimeConfig().public.apiBaseUrl;
 
 export interface ResultItem {
     filename: string;


### PR DESCRIPTION
## Summary
- make Flask API port configurable via `API_PORT`
- add runtime configuration in Nuxt to expose `API_BASE_URL`
- use runtime config when calling the API
- document `API_PORT` and `API_BASE_URL` in README

## Testing
- `python -m py_compile api.py`


------
https://chatgpt.com/codex/tasks/task_e_6840fcf48710832da4169abac21cd761