### PR TITLE
Fix Nuxt runtime composable usage in API service

### DIFF
--- a/camelia-ui/services/api.ts
+++ b/camelia-ui/services/api.ts
@@ -1,4 +1,12 @@
-const API_BASE_URL: string = useRuntimeConfig().public.apiBaseUrl;
+/**
+ * Helper to access the API base URL from runtime configuration. The
+ * `useRuntimeConfig` composable must be called within a Nuxt context (such as
+ * inside a composable or Vue component). Wrapping the call in a function
+ * ensures it executes at runtime rather than during module evaluation.
+ */
+function getApiBaseUrl(): string {
+    return useRuntimeConfig().public.apiBaseUrl;
+}
 
 export interface ResultItem {
     filename: string;
@@ -35,6 +43,7 @@ export async function processImages(
     formData.append('model_type', processingType);
 
     // Make API request to process images
+    const API_BASE_URL = getApiBaseUrl();
     const response = await fetch(`${API_BASE_URL}/process`, {
         method: 'POST',
         body: formData
@@ -60,6 +69,7 @@ export async function checkProcessingStatus(sessionId: string): Promise<{
     status: 'processing' | 'completed' | 'error';
     results?: Array<{ filename: string }>;
 }> {
+    const API_BASE_URL = getApiBaseUrl();
     const response = await fetch(`${API_BASE_URL}/status/${sessionId}`);
 
     if (!response.ok) {
@@ -78,6 +88,7 @@ export async function checkProcessingStatus(sessionId: string): Promise<{
  * Stream logs from the processing job
  */
 export function streamProcessingLogs(sessionId: string, onLog: (log: string) => void): () => void {
+    const API_BASE_URL = getApiBaseUrl();
     const evtSource = new EventSource(`${API_BASE_URL}/logs/${sessionId}`);
 
     evtSource.onmessage = (event) => {
@@ -105,6 +116,7 @@ export function transformResults(
     sessionId: string,
     results: Array<{ filename: string }>
 ): ResultItem[] {
+    const API_BASE_URL = getApiBaseUrl();
     return results.map((result) => {
         return {
             filename: result.filename,
@@ -120,6 +132,7 @@ export function transformResults(
  */
 export async function cancelProcessingJob(sessionId: string): Promise<boolean> {
     try {
+        const API_BASE_URL = getApiBaseUrl();
         const response = await fetch(`${API_BASE_URL}/cancel/${sessionId}`, {
             method: 'POST'
         });
@@ -145,6 +158,7 @@ export async function reinpaintImage(
     filename: string,
     mask: Blob
 ): Promise<ResultItem> {
+    const API_BASE_URL = getApiBaseUrl();
     const formData = new FormData();
     formData.append('mask', mask, 'mask.png');
 


### PR DESCRIPTION
## Summary
- wrap `useRuntimeConfig` in helper function
- reference runtime config within each service method

## Testing
- `npm run build` *(fails: nuxt not found)*

------
https://chatgpt.com/codex/tasks/task_e_684119586224832d9f08462e1d4cf51d